### PR TITLE
Fix logging.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,18 +10,19 @@ dependencies:
   - role: dwcramer.upstart
     upstart_name: elastalert
     upstart_exec_path: "/opt/elastalert/venv/bin/python -- -m elastalert.elastalert --verbose --config /etc/elastalert/config.yaml"
-    upstart_log_path: /var/log/elastalert.log
+    upstart_log_path: /var/log/elastalert/elastalert.log
     upstart_user: elastalert
     upstart_group: elastalert
     upstart_start_on:
       - startup
     upstart_stop_on:
       - shutdown
+    upstart_capture_errors: yes
   - role: tersmitten.logrotated
     logrotated_logrotate_d_files:
       elastalert:
         - logs:
-            - /var/log/elastalert.log
+            - /var/log/elastalert/elastalert.log
           daily: true
           rotate: 7
           copytruncate: true


### PR DESCRIPTION
- log to the log directory that dwcramer.upstart creates
- enable stderr redirection, since Elastalert logs to stderr

Note:
For Elastalert output to show up properly in the log file, the PR I
submitted to dwcramer.upstart must also be included.
